### PR TITLE
Adding Custom Level Export Features

### DIFF
--- a/fast64_internal/sm64/sm64_collision.py
+++ b/fast64_internal/sm64/sm64_collision.py
@@ -110,6 +110,7 @@ class Collision:
         self.triangles = {}
         self.specials = []
         self.water_boxes = []
+        self.incompatibleCollisionOverride = None
 
     def set_addr(self, startAddress):
         startAddress = get64bitAlignedAddr(startAddress)
@@ -133,6 +134,8 @@ class Collision:
         for vertex in self.vertices:
             data.source += "\t" + vertex.to_c()
         for collisionType, triangles in self.triangles.items():
+            if self.incompatibleCollisionOverride and 'SPECFLAG' in collisionType:
+                collisionType = self.incompatibleCollisionOverride
             data.source += "\tCOL_TRI_INIT(" + collisionType + ", " + str(len(triangles)) + "),\n"
             for triangle in triangles:
                 data.source += "\t" + triangle.to_c()
@@ -374,7 +377,7 @@ def exportCollisionInsertableBinary(obj, transformMatrix, filepath, includeSpeci
     return data
 
 
-def exportCollisionCommon(obj, transformMatrix, includeSpecials, includeChildren, name, areaIndex):
+def exportCollisionCommon(obj, transformMatrix, includeSpecials, includeChildren, name, areaIndex, exportCollisionOverride):
     bpy.ops.object.select_all(action="DESELECT")
     obj.select_set(True)
 
@@ -394,6 +397,7 @@ def exportCollisionCommon(obj, transformMatrix, includeSpecials, includeChildren
         raise Exception(str(e))
 
     collision = Collision(toAlnum(name) + "_collision")
+    collision.incompatibleCollisionOverride = exportCollisionOverride
     for collisionType, faces in collisionDict.items():
         collision.triangles[collisionType] = []
         for (faceVerts, specialParam, room) in faces:

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -1218,7 +1218,7 @@ class SM64_ExportLevel(ObjectDataExporter):
                     os.remove(oldLevel)
 
             if context.scene.levelPostCommand:
-                subprocess.Popen([context.scene.levelPostCommand], shell=True])
+                subprocess.Popen([context.scene.levelPostCommand], shell=True)
 
             cameraWarning(self, fileStatus)
             starSelectWarning(self, fileStatus)

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -1211,6 +1211,12 @@ class SM64_ExportLevel(ObjectDataExporter):
                 DLFormat.Static,
             )
 
+            if context.scene.levelDeleteOldLevel:
+                # Delete old *.lvl if exists
+                oldLevel = os.path.join(exportPath, f'level_{levelName}_entry.lvl')
+                if os.path.exists(oldLevel):
+                    os.remove(oldLevel)
+
             cameraWarning(self, fileStatus)
             starSelectWarning(self, fileStatus)
 
@@ -1252,6 +1258,7 @@ class SM64_ExportLevelPanel(SM64_Panel):
             prop_split(col, context.scene, "levelName", "Name")
             prop_split(col, context.scene, "levelAreas", "Areas")
             prop_split(col, context.scene, "levelCollisionOverride", "Collision Override")
+            prop_split(col, context.scene, "levelDeleteOldLevel", "Delete Old Level")
             customExportWarning(col)
         else:
             col.prop(context.scene, "levelOption")
@@ -1297,6 +1304,7 @@ def sm64_level_register():
                                                           description="(e.g., 'all' '1,3')")
     bpy.types.Scene.levelCollisionOverride = bpy.props.StringProperty(name='Collision Override', default='',
                                                                       description='Type when collisionType is coop-incompatible (i.e., *SPECFLAG*)')
+    bpy.types.Scene.levelDeleteOldLevel = bpy.props.BoolProperty(name="Delete Old *.lvl in Custom Export Path", default=True)
 
 
 def sm64_level_unregister():
@@ -1309,3 +1317,4 @@ def sm64_level_unregister():
     del bpy.types.Scene.levelOption
     del bpy.types.Scene.levelAreas
     del bpy.types.Scene.levelCollisionOverride
+    del bpy.types.Scene.levelDeleteOldLevel

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -698,7 +698,7 @@ class SM64OptionalFileStatus:
 
 
 def exportLevelC(
-    obj, transformMatrix, f3dType, isHWv1, levelName, exportDir, exportAreas, savePNG, customExport, levelCameraVolumeName, DLFormat
+    obj, transformMatrix, f3dType, isHWv1, levelName, exportDir, exportAreas, exportCollisionOverride, savePNG, customExport, levelCameraVolumeName, DLFormat
 ):
 
     fileStatus = SM64OptionalFileStatus()
@@ -796,7 +796,7 @@ def exportLevelC(
 
         # Write collision
         collision = exportCollisionCommon(
-            child, transformMatrix, True, True, levelName + "_" + areaName, child.areaIndex
+            child, transformMatrix, True, True, levelName + "_" + areaName, child.areaIndex, exportCollisionOverride
         )
         collisionC = collision.to_c()
         colFile = open(os.path.join(areaDir, "collision.inc.c"), "w", newline="\n")
@@ -1204,6 +1204,7 @@ class SM64_ExportLevel(ObjectDataExporter):
                 levelName,
                 exportPath,
                 context.scene.levelAreas,
+                context.scene.levelCollisionOverride,
                 context.scene.saveTextures,
                 context.scene.levelCustomExport,
                 triggerName,
@@ -1250,6 +1251,7 @@ class SM64_ExportLevelPanel(SM64_Panel):
             prop_split(col, context.scene, "levelExportPath", "Directory")
             prop_split(col, context.scene, "levelName", "Name")
             prop_split(col, context.scene, "levelAreas", "Areas")
+            prop_split(col, context.scene, "levelCollisionOverride", "Collision Override")
             customExportWarning(col)
         else:
             col.prop(context.scene, "levelOption")
@@ -1293,6 +1295,8 @@ def sm64_level_register():
     bpy.types.Scene.levelCustomExport = bpy.props.BoolProperty(name="Custom Export Path")
     bpy.types.Scene.levelAreas = bpy.props.StringProperty(name="Areas to Export", default="all",
                                                           description="(e.g., 'all' '1,3')")
+    bpy.types.Scene.levelCollisionOverride = bpy.props.StringProperty(name='Collision Override', default='',
+                                                                      description='Type when collisionType is coop-incompatible (i.e., *SPECFLAG*)')
 
 
 def sm64_level_unregister():
@@ -1304,3 +1308,4 @@ def sm64_level_unregister():
     del bpy.types.Scene.levelCustomExport
     del bpy.types.Scene.levelOption
     del bpy.types.Scene.levelAreas
+    del bpy.types.Scene.levelCollisionOverride

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -1,4 +1,4 @@
-import bpy, os, math, re, shutil, mathutils
+import bpy, os, math, re, shutil, subprocess, mathutils
 from collections import defaultdict
 from bpy.utils import register_class, unregister_class
 from ..panels import SM64_Panel
@@ -1217,6 +1217,9 @@ class SM64_ExportLevel(ObjectDataExporter):
                 if os.path.exists(oldLevel):
                     os.remove(oldLevel)
 
+            if context.scene.levelPostCommand:
+                subprocess.Popen([context.scene.levelPostCommand], shell=True])
+
             cameraWarning(self, fileStatus)
             starSelectWarning(self, fileStatus)
 
@@ -1259,6 +1262,7 @@ class SM64_ExportLevelPanel(SM64_Panel):
             prop_split(col, context.scene, "levelAreas", "Areas")
             prop_split(col, context.scene, "levelCollisionOverride", "Collision Override")
             prop_split(col, context.scene, "levelDeleteOldLevel", "Delete Old Level")
+            prop_split(col, context.scene, "levelPostCommand", "Post-Command")
             customExportWarning(col)
         else:
             col.prop(context.scene, "levelOption")
@@ -1302,9 +1306,11 @@ def sm64_level_register():
     bpy.types.Scene.levelCustomExport = bpy.props.BoolProperty(name="Custom Export Path")
     bpy.types.Scene.levelAreas = bpy.props.StringProperty(name="Areas to Export", default="all",
                                                           description="(e.g., 'all' '1,3')")
-    bpy.types.Scene.levelCollisionOverride = bpy.props.StringProperty(name='Collision Override', default='',
-                                                                      description='Type when collisionType is coop-incompatible (i.e., *SPECFLAG*)')
+    bpy.types.Scene.levelCollisionOverride = bpy.props.StringProperty(name="Collision Override", default="",
+                                                                      description="Type when collisionType is coop-incompatible (i.e., *SPECFLAG*)")
     bpy.types.Scene.levelDeleteOldLevel = bpy.props.BoolProperty(name="Delete Old *.lvl in Custom Export Path", default=True)
+    bpy.types.Scene.levelPostCommand = bpy.props.StringProperty(name="Post-Command", default="",
+                                                                description="Command to run after export is complete")
 
 
 def sm64_level_unregister():
@@ -1318,3 +1324,4 @@ def sm64_level_unregister():
     del bpy.types.Scene.levelAreas
     del bpy.types.Scene.levelCollisionOverride
     del bpy.types.Scene.levelDeleteOldLevel
+    del bpy.types.Scene.levelPostCommand

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -1160,7 +1160,16 @@ class SM64_ExportLevel(ObjectDataExporter):
                         if obj.data is None and obj.sm64_obj_type == "Level Root":
                             break
                 if obj is None or obj.sm64_obj_type != "Level Root":
-                    raise PluginError("Cannot find level empty.")
+                    # Try to find Level Object
+                    for _obj in bpy.data.objects:
+                        if hasattr(_obj, 'sm64_obj_type') and _obj.sm64_obj_type == "Level Root":
+                            obj = _obj
+                            break
+
+                    # Recheck if obj isn't a Level Root
+                    if obj is None or obj.sm64_obj_type != "Level Root":
+                        raise PluginError("Cannot find Level Root in Scene.")
+
                 selectSingleObject(obj)
 
             scaleValue = bpy.context.scene.blenderToSM64Scale


### PR DESCRIPTION
* Added `Areas (StringProperty)` (w/ a default of `all`) to allow exporting a comma-separated whitelist of areas - instead of the entire level (i.e., `1,3`)
* Added `Collision Type (StringProperty)` to allow overriding collisionTypes unsupported by coop (i.e., `*SPECFLAG*`). If left blank, does not affect collisionType (i.e., SURFACE_DEFAULT) (Optional).
* Added `Delete Old Level (BoolProperty)` (w/ default of `True`) to delete the *.lvl file for the level being exported (so after exporting you don't have to delete the *.lvl before launching sm64ex-coop
* Added `Post-Command (StringProperty)` to allow executing a command after export (i.e., Launching sm64ex-coop). Does nothing if left blank (Optional).
* Automagically selecting the first `Level Root` when no Objects are selected/highlighted in the scene. No more Level empty errors (unless no Level Root *actually* exists)

All features are available when using Custom Export Path:
![image](https://github.com/Agent-11/fast64-coop/assets/730767/eadb59b8-0e2c-4943-8831-93512f7fde17)